### PR TITLE
Fix snap rotation

### DIFF
--- a/Unit13.pas
+++ b/Unit13.pas
@@ -347,6 +347,8 @@ begin
                       begin
                         floor[sfloor].Monster[selected].Pos_X := floor[sfloor].Monster[j].Pos_X;
                         mymonst[selected].PositionX := mymonst[j].PositionX;
+                        if (FPlacementOptions.chkSnapRotate.Checked) then
+                          floor[sfloor].Monster[selected].Direction := floor[sfloor].Monster[j].Direction;
                         GenerateMonsterName(Floor[sfloor].Monster[selected],selected,2);
                       end;
                     end;
@@ -366,15 +368,12 @@ begin
                       begin
                         floor[sfloor].Monster[selected].Pos_Y := floor[sfloor].Monster[j].Pos_Y;
                         mymonst[selected].PositionY := mymonst[j].PositionY;
+                        if (FPlacementOptions.chkSnapRotate.Checked) then
+                          floor[sfloor].Monster[selected].Direction := floor[sfloor].Monster[j].Direction;
                         GenerateMonsterName(Floor[sfloor].Monster[selected],selected,2);
                       end;
                     end;
                 end;
-              end;
-              if (FPlacementOptions.chkSnapRotate.Checked) then
-              begin
-                floor[sfloor].Monster[selected].Direction := floor[sfloor].Monster[j].Direction;
-                GenerateMonsterName(Floor[sfloor].Monster[selected],selected,2);
               end;
             end;
 
@@ -409,6 +408,8 @@ begin
                       begin
                         floor[sfloor].Obj[selected].Pos_X := floor[sfloor].Obj[j].Pos_X;
                         myobj[selected].PositionX := myobj[j].PositionX;
+                        if (FPlacementOptions.chkSnapRotate.Checked) then
+                          floor[sfloor].Obj[selected].unknow6 := floor[sfloor].Obj[j].unknow6;
                         myobj[selected].Free;
                         Generateobj(floor[sfloor].obj[selected],selected);
                       end;
@@ -429,17 +430,13 @@ begin
                       begin
                         floor[sfloor].Obj[selected].Pos_Y := floor[sfloor].Obj[j].Pos_Y;
                         myobj[selected].PositionY := myobj[j].PositionY;
+                        if (FPlacementOptions.chkSnapRotate.Checked) then
+                          floor[sfloor].Obj[selected].unknow6 := floor[sfloor].Obj[j].unknow6;
                         myobj[selected].Free;
                         Generateobj(floor[sfloor].obj[selected],selected);
                       end;
                     end;
                 end;
-              end;
-              if (FPlacementOptions.chkSnapRotate.Checked) then
-              begin
-                floor[sfloor].Obj[selected].unknow6 := floor[sfloor].Obj[j].unknow6;
-                myobj[selected].Free;
-                Generateobj(floor[sfloor].obj[selected],selected);
               end;
             end;
 

--- a/main.pas
+++ b/main.pas
@@ -5695,6 +5695,9 @@ begin
                 or ((round(Floor[sfloor].Monster[j].Pos_X - i)) = round(px)) then
                 begin
                   Floor[sfloor].Monster[MoveSel].Pos_X := Floor[sfloor].Monster[j].Pos_X;
+                  // Match monster's rotations if enabled
+                  if FPlacementOptions.chkSnapRotate.Checked then
+                    Floor[sfloor].Monster[MoveSel].Direction := Floor[sfloor].Monster[j].Direction;
                 end;
               end;
           end;
@@ -5713,14 +5716,12 @@ begin
                 or ((round(Floor[sfloor].Monster[j].Pos_Y - i)) = round(py)) then
                 begin
                   Floor[sfloor].Monster[MoveSel].Pos_Y := Floor[sfloor].Monster[j].Pos_Y;
+                  if FPlacementOptions.chkSnapRotate.Checked then
+                    Floor[sfloor].Monster[MoveSel].Direction := Floor[sfloor].Monster[j].Direction;
                 end;
               end;
           end;
         end;
-
-        // Match monster's rotations if enabled
-        if FPlacementOptions.chkSnapRotate.Checked then
-          Floor[sfloor].Monster[MoveSel].Direction := Floor[sfloor].Monster[j].Direction;
       end;
 
       // look around to find the best pz
@@ -5770,6 +5771,9 @@ begin
                 or ((round(Floor[sfloor].Obj[j].Pos_X - i)) = round(px)) then
                 begin
                   Floor[sfloor].Obj[MoveSel].Pos_X := Floor[sfloor].Obj[j].Pos_X;
+                  // Match object's rotations if enabled
+                  if FPlacementOptions.chkSnapRotate.Checked then
+                    Floor[sfloor].Obj[MoveSel].unknow6 := Floor[sfloor].Obj[j].unknow6;
                 end;
               end;
           end;
@@ -5788,14 +5792,12 @@ begin
                 or ((round(Floor[sfloor].Obj[j].Pos_Y - i)) = round(py)) then
                 begin
                   Floor[sfloor].Obj[MoveSel].Pos_Y := Floor[sfloor].Obj[j].Pos_Y;
+                  if FPlacementOptions.chkSnapRotate.Checked then
+                    Floor[sfloor].Obj[MoveSel].unknow6 := Floor[sfloor].Obj[j].unknow6;
                 end;
               end;
           end;
         end;
-
-        // Match object's rotations if enabled
-        if FPlacementOptions.chkSnapRotate.Checked then
-          Floor[sfloor].Obj[MoveSel].unknow6 := Floor[sfloor].Obj[j].unknow6;
       end;
 
       if not altdw or firstdrop then


### PR DESCRIPTION
Sorry for so many PRs and commits! Kayak found a bug with snap rotation. I was setting the monster/object direction after the loops ended instead of in the middle after X/Y are aligned.